### PR TITLE
Fix assembling programs with labels that reference forward points of the program

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,6 @@ format:
 	shopt -s globstar && rustfmt **/*.rs
 
 ci: clean
-	docker build -t lib-rv32-test . -f ci/Dockerfile
+	docker build -t lib-rv32-test .
 	docker run -it --rm lib-rv32-test .
 	docker rmi lib-rv32-test

--- a/assembler/src/parse.rs
+++ b/assembler/src/parse.rs
@@ -95,7 +95,7 @@ macro_rules! match_func3 {
             "sra" | "srai" | "srl" | "srli" => FUNC3_SR,
             "or" | "ori" => FUNC3_OR,
             "and" | "andi" => FUNC3_AND,
-            _ => unreachable!(),
+            _ => 0,
         }
     };
 }


### PR DESCRIPTION
Forward labels will now be parsed correctly. Two passes are made when assembling: first parse the labels into a hash-map, second assemble the program replacing labels with immediates.