### PR TITLE
ref: Add changelogs for sub-projects

### DIFF
--- a/assembler/CHANGELOG.md
+++ b/assembler/CHANGELOG.md
@@ -1,0 +1,14 @@
+# 0.3
+
+- Fix parsing labels which occur at a future point in the program
+- Add initial support for psuedo-instructions
+
+# 0.2
+
+- WASM support
+
+# 0.1
+
+- Experimental assembler
+- Support base instructions
+- Unreleased

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.2
+
+Initial release

--- a/isa-sim/CHANGELOG.md
+++ b/isa-sim/CHANGELOG.md
@@ -1,0 +1,7 @@
+# 0.2
+
+- Use wrapping add
+
+# 0.1
+
+- Initial release

--- a/mcu/CHANGELOG.md
+++ b/mcu/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.2
+
+- Initial release


### PR DESCRIPTION
Create changelogs for each sub-project. Since everything began as a monolithic project,
that is considered 0.1.0. That is why most begin at 0.2.0.
